### PR TITLE
feat(options): custom gif location

### DIFF
--- a/src/Neko.ts
+++ b/src/Neko.ts
@@ -50,6 +50,7 @@ export default class Neko {
   private idleAnimation: string | null = null;
   private idleAnimationFrame: number = 0;
   private nekoSpeed: number = 10;
+  private nekoGif: string = NekoGif;
 
   private distanceFromMouse: number = 25;
 
@@ -224,6 +225,17 @@ export default class Neko {
      * });
      */
     defaultState?: "awake" | "sleep";
+    /**
+     * Which path to fetch the gif from or which imported *.gif module to use
+     * @default "imported content of ./neko.gif"
+     * @type string
+     * @example
+     * const neko = new Neko({
+     *   gifPathOrModule: "/my-path/to/neko.gif",
+     *   gifPathOrModule: await import("./neko.gif"),
+     * });
+     */
+    gifPathOrModule?: string;
   }) {
     // get element with attribute data-neko
     const isNekoAlive = document.querySelector("[data-neko]") as HTMLDivElement;
@@ -258,6 +270,10 @@ export default class Neko {
       this.isAwake = false;
     }
 
+    if (options && options.gifPathOrModule) {
+      this.nekoGif = options.gifPathOrModule;
+    }
+
     this.size =
       options && options.nekoSize ? options.nekoSize : NekoSizeVariations.SMALL;
     this.nekoId = options && options.nekoId ? options.nekoId : this.nekoId;
@@ -286,7 +302,7 @@ export default class Neko {
 
     this.nekoEl.style.position = "fixed";
     this.nekoEl.style.imageRendering = "pixelated";
-    this.nekoEl.style.backgroundImage = `url(${NekoGif})`;
+    this.nekoEl.style.backgroundImage = `url(${this.nekoGif})`;
     this.nekoEl.style.backgroundSize = "calc(800%) calc(400%)";
     this.nekoEl.style.userSelect = "none";
     this.nekoEl.style.pointerEvents = "none";

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,6 @@
+declare module "*.gif" {
+  const value: string;
+  export default value;
+}
+
+   


### PR DESCRIPTION
Adds a `gifPathOrModule` option to specify a custom gif. This is useful for:
- Customization: if someone wants another animation
- Optimization: by leveraging the http cache when providing an url instead of an import