### PR TITLE
BUGFIX: Incorrect data string used for neko destruction

### DIFF
--- a/src/Neko.ts
+++ b/src/Neko.ts
@@ -446,7 +446,7 @@ export default class Neko {
   public destroy(id?: number) {
     if (id && id !== this.nekoId) return;
     else {
-      const neko = document.querySelector(`[data-neko="neko-${this.nekoId}"]`);
+      const neko = document.querySelector(`[data-neko="${this.nekoId}"]`);
       if (neko) {
         neko.remove();
         clearInterval((window as any).nekoInterval);


### PR DESCRIPTION
Calling `destroy()` on a neko instance doesn't work, as the selector is specified incorrectly. This small bugfix fixes the issue. 